### PR TITLE
feature: Load WiFiManagerProvisioning.json from external storage on startup

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -26,6 +26,9 @@
     <uses-permission android:name="android.permission.CHANGE_WIFI_STATE" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+        android:maxSdkVersion="29"/>
 
     <uses-feature android:name="android.hardware.wifi" />
 

--- a/app/src/main/java/com/hmdm/wifimanager/ExternalConfigLoader.java
+++ b/app/src/main/java/com/hmdm/wifimanager/ExternalConfigLoader.java
@@ -1,0 +1,128 @@
+package com.hmdm.wifimanager;
+
+import android.content.Context;
+import android.os.Build;
+import android.os.Environment;
+import android.Manifest;
+import android.text.TextUtils;
+
+import androidx.annotation.Nullable;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonSyntaxException;
+import com.hmdm.MDMService;
+import com.hmdm.wifimanager.model.MDMConfig;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.LinkedHashSet;
+
+/**
+ * Loads WiFi manager provisioning data from an external JSON file.
+ * Intended for one-time provisioning on first launch. The file is read only when
+ * the provisioning payload is not yet applied. The file is searched in public
+ * external locations (Downloads and external storage root) when read access is
+ * allowed. After applying, the file is deleted.
+ *
+ * Example WiFiManagerProvisioning.json:
+ * {
+ *   "allAllowed": false,
+ *   "freeAllowed": false,
+ *   "allowed": [
+ *     {
+ *       "ssid": "CorpWiFi",
+ *       "bssid": "00:11:22:33:44:55",
+ *       "password": "secret-password",
+ *       "hidden": false,
+ *       "security": "WPA_PSK"
+ *     }
+ *   ]
+ * }
+ */
+public class ExternalConfigLoader {
+
+    private static final String TAG = "HeadwindWiFi";
+    private static final String FILE_NAME = "WiFiManagerProvisioning.json";
+
+    private final Context context;
+    private final Gson gson = new Gson();
+
+    public ExternalConfigLoader(Context context) {
+        this.context = context.getApplicationContext();
+    }
+
+    @Nullable
+    public MDMConfig loadIfPresent() {
+        File configFile = locateConfigFile();
+        if (configFile == null) {
+            return null;
+        }
+        try {
+            String payload = readFile(configFile);
+            if (TextUtils.isEmpty(payload)) {
+                MDMService.Log.w(TAG, "Provisioning file is empty: " + configFile);
+                return null;
+            }
+            MDMConfig config = gson.fromJson(payload, MDMConfig.class);
+            if (config == null) {
+                MDMService.Log.w(TAG, "Failed to parse provisioning file: " + configFile);
+                return null;
+            }
+            if (!configFile.delete()) {
+                MDMService.Log.w(TAG, "Unable to delete provisioning file: " + configFile);
+            }
+            MDMService.Log.i(TAG, "WiFi manager provisioning applied from " + configFile.getAbsolutePath());
+            return config;
+        } catch (IOException | JsonSyntaxException e) {
+            MDMService.Log.w(TAG, "Failed to load WiFi provisioning file: " + e.getMessage());
+        }
+        return null;
+    }
+
+    @Nullable
+    private File locateConfigFile() {
+        LinkedHashSet<File> candidates = new LinkedHashSet<>();
+        // Public locations only when we are allowed to read them.
+        if (canAccessPublicExternal()) {
+            File downloadsDir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS);
+            if (downloadsDir != null) {
+                candidates.add(new File(downloadsDir, FILE_NAME));
+            }
+            File externalRoot = Environment.getExternalStorageDirectory();
+            if (externalRoot != null) {
+                candidates.add(new File(externalRoot, FILE_NAME));
+            }
+        }
+        for (File candidate : candidates) {
+            if (candidate != null && candidate.exists()) {
+                return candidate;
+            }
+        }
+        return null;
+    }
+
+    private boolean canAccessPublicExternal() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            return context.checkSelfPermission(Manifest.permission.READ_EXTERNAL_STORAGE)
+                    == android.content.pm.PackageManager.PERMISSION_GRANTED;
+        }
+        return true;
+    }
+
+    private String readFile(File file) throws IOException {
+        FileInputStream fis = new FileInputStream(file);
+        try {
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            byte[] buffer = new byte[4096];
+            int read;
+            while ((read = fis.read(buffer)) != -1) {
+                baos.write(buffer, 0, read);
+            }
+            return baos.toString("UTF-8");
+        } finally {
+            fis.close();
+        }
+    }
+}

--- a/app/src/main/java/com/hmdm/wifimanager/ui/activities/MainActivity.java
+++ b/app/src/main/java/com/hmdm/wifimanager/ui/activities/MainActivity.java
@@ -34,6 +34,7 @@ import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.view.MenuItem;
+import android.net.NetworkInfo;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -48,6 +49,7 @@ import com.hmdm.MDMPushHandler;
 import com.hmdm.MDMPushMessage;
 import com.hmdm.MDMService;
 import com.hmdm.wifimanager.BuildConfig;
+import com.hmdm.wifimanager.ExternalConfigLoader;
 import com.hmdm.wifimanager.Presenter;
 import com.hmdm.wifimanager.R;
 import com.hmdm.wifimanager.model.MDMConfig;
@@ -82,6 +84,8 @@ public class MainActivity extends AppCompatActivity implements MDMService.Result
     private MDMService mdmService;
     private boolean mdmConnected = false;
     private PushHandler pushHandler;
+    private boolean provisioningConfigActive = false;
+    private MDMConfig provisioningConfig;
 
     private void initPreferences() {
          preferences = getApplicationContext().getSharedPreferences("com.hmdm.wifimanager.PREFERENCES", Context.MODE_PRIVATE);
@@ -185,6 +189,12 @@ public class MainActivity extends AppCompatActivity implements MDMService.Result
                 request.add(Manifest.permission.ACCESS_FINE_LOCATION);
             if (ActivityCompat.checkSelfPermission(this, Manifest.permission.ACCESS_COARSE_LOCATION) != PackageManager.PERMISSION_GRANTED)
                 request.add(Manifest.permission.ACCESS_COARSE_LOCATION);
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M &&
+                    ActivityCompat.checkSelfPermission(this, Manifest.permission.READ_EXTERNAL_STORAGE) != PackageManager.PERMISSION_GRANTED)
+                request.add(Manifest.permission.READ_EXTERNAL_STORAGE);
+            if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.Q &&
+                    ActivityCompat.checkSelfPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE) != PackageManager.PERMISSION_GRANTED)
+                request.add(Manifest.permission.WRITE_EXTERNAL_STORAGE);
 
             if (request.size() > 0 && doRequest) {
                 String[] permissions = new String[request.size()];
@@ -205,11 +215,11 @@ public class MainActivity extends AppCompatActivity implements MDMService.Result
         }
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-            needEnable = true;
             LocationManager locationManager = (LocationManager) getSystemService(LOCATION_SERVICE);
-            if (locationManager != null) {
-                if (locationManager.isProviderEnabled(LocationManager.NETWORK_PROVIDER))
-                    needEnable = false;
+            if (locationManager == null) {
+                needEnable = true;
+            } else {
+                needEnable = !locationManager.isLocationEnabled();
             }
 
             if (needEnable) {
@@ -296,6 +306,12 @@ public class MainActivity extends AppCompatActivity implements MDMService.Result
                                 ArrayList<String> request = new ArrayList<>();
                                 request.add(Manifest.permission.ACCESS_FINE_LOCATION);
                                 request.add(Manifest.permission.ACCESS_COARSE_LOCATION);
+                                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                                    request.add(Manifest.permission.READ_EXTERNAL_STORAGE);
+                                }
+                                if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.Q) {
+                                    request.add(Manifest.permission.WRITE_EXTERNAL_STORAGE);
+                                }
 
                                 String[] permissions = new String[request.size()];
                                 permissions = request.toArray(permissions);
@@ -377,20 +393,40 @@ public class MainActivity extends AppCompatActivity implements MDMService.Result
     }
 
     private void getConfig() {
+        NetworkInfo.State state = Presenter.getInstance().getConnectedState();
+        boolean wifiConnected = state == NetworkInfo.State.CONNECTED;
+        if (wifiConnected && provisioningConfigActive) {
+            provisioningConfigActive = false;
+            provisioningConfig = null;
+        }
         MDMConfig config = null;
-
-        if (mdmConnected) {
-            try {
-                config = new Gson().fromJson(MDMService.Preferences.get("config",
-                        "{\"allAllowed\":true,\"allowed\":[]}"), MDMConfig.class);
-            } catch (Exception e) {
-                e.printStackTrace();
-                config = null;
-                //showAlertNoConfig();
+        if (!wifiConnected) {
+            if (provisioningConfigActive && provisioningConfig != null) {
+                config = provisioningConfig;
+            } else {
+                config = new ExternalConfigLoader(this).loadIfPresent();
+                if (config != null) {
+                    provisioningConfigActive = true;
+                    provisioningConfig = config;
+                    Presenter.getInstance().setWiFiState(true);
+                }
             }
         }
-        else
-            mdmService.connect(this, this);
+
+        if (config == null) {
+            if (mdmConnected) {
+                try {
+                    config = new Gson().fromJson(MDMService.Preferences.get("config",
+                            "{\"allAllowed\":true,\"allowed\":[]}"), MDMConfig.class);
+                } catch (Exception e) {
+                    e.printStackTrace();
+                    config = null;
+                    //showAlertNoConfig();
+                }
+            }
+            else
+                mdmService.connect(this, this);
+        }
 
         if (config == null)
             config = new MDMConfig();

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -64,4 +64,5 @@
         <item>Хороший</item>
         <item>Отличный</item>
     </string-array>
+    <string name="encryption_open">Нет</string>
 </resources>


### PR DESCRIPTION
Summary of behaviour:

On startup, the plugin loads WiFiManagerProvisioning.json only when Wi‑Fi is disconnected (to avoid disrupting an active connection). After successful parsing and apply, the file is deleted; the provisioning config stays active until the device connects, then it is cleared.

Permissions notes:
Reads from public external locations (Downloads or external storage root) and requires READ_EXTERNAL_STORAGE on Android 6+.
On Android 11+, the plugin still relies on READ_EXTERNAL_STORAGE (no “All files access” handling), so access depends on scoped‑storage rules.
Deletion: on Android 6–9 it may require WRITE_EXTERNAL_STORAGE, and on Android 10+ scoped storage can block deletion unless the file is managed via SAF. If deletion fails, a warning is logged and the app continues.

Example JSON (WiFiManagerProvisioning.json):
{
  "allAllowed": false,
  "freeAllowed": false,
  "allowed": [
    {
      "ssid": "CorpWiFi",
      "bssid": "00:11:22:33:44:55",
      "password": "secret-password",
      "hidden": false,
      "security": "WPA_PSK"
    }
  ]
}